### PR TITLE
Run pattern-lab generate only on a local install

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "SFGOV Pattern Lab library",
   "main": "index.js",
   "scripts": {
-    "install": "php pattern-lab/core/console --generate"
+    "prepublish": "php pattern-lab/core/console --generate"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
(also before publishing when we get to that point)

Otherwise, using this as a dependency of another JS project causes it to attempt to run pattern-lab. This is unnecessary since the dist/ has already been generated.

Specifically this was causing my noticing project build to fail as it tries to run pattern-lab during the dependency install: https://circleci.com/gh/SFDigitalServices/neighborhood-noticing/17.

See https://docs.npmjs.com/misc/scripts for description of ordained npm scripts.